### PR TITLE
Fix direct license Keychain access

### DIFF
--- a/SaneClick/SaneClickApp.swift
+++ b/SaneClick/SaneClickApp.swift
@@ -265,19 +265,7 @@ struct SaneClickApp: App {
         @State private var licenseService = LicenseService(
             appName: "SaneClick",
             checkoutURL: LicenseService.directCheckoutURL(appSlug: "saneclick"),
-            // Store the license in the modern data-protection keychain so a Developer ID
-            // signature change across direct updates no longer re-prompts ("wants to use
-            // your confidential information") on every keychain item (TN3137). The access
-            // group reuses the app's existing application-group entitlement, which macOS
-            // also exposes as a keychain access group — so no new entitlement or
-            // provisioning profile is required. The service matches the legacy
-            // login-keychain item so the one-time migration finds it. (App Store builds
-            // are sandboxed and unaffected, so the #if APP_STORE branch keeps the old
-            // service-only keychain.)
-            keychain: KeychainService(
-                service: "com.saneclick.SaneClick",
-                accessGroup: "M78L6FXD48.group.com.saneclick.app"
-            ),
+            keychain: KeychainService(service: "com.saneclick.SaneClick"),
             directCopy: LicenseService.DirectCopy.saneClick,
             proTrial: .init(storageKeyPrefix: "saneclick.pro_trial")
         )

--- a/SaneClick/Services/ScriptExecutor.swift
+++ b/SaneClick/Services/ScriptExecutor.swift
@@ -300,13 +300,7 @@ final class ScriptExecutor: @unchecked Sendable {
             service = LicenseService(
                 appName: "SaneClick",
                 checkoutURL: LicenseService.directCheckoutURL(appSlug: "saneclick"),
-                // Match the host app's data-protection keychain namespace. Without
-                // this access group, Finder-triggered Pro actions can see an empty
-                // legacy keychain while Settings correctly reports an active unlock.
-                keychain: KeychainService(
-                    service: "com.saneclick.SaneClick",
-                    accessGroup: "M78L6FXD48.group.com.saneclick.app"
-                ),
+                keychain: KeychainService(service: "com.saneclick.SaneClick"),
                 directCopy: LicenseService.DirectCopy.saneClick,
                 proTrial: .init(storageKeyPrefix: "saneclick.pro_trial")
             )

--- a/Tests/ScriptExecutorTests.swift
+++ b/Tests/ScriptExecutorTests.swift
@@ -439,8 +439,8 @@ struct ScriptExecutorTests {
         #expect(source.contains("itemCount=\\(request.paths.count)"))
     }
 
-    @Test("Direct executor and host app share the Pro keychain access group")
-    func directExecutorUsesHostAppKeychainAccessGroup() throws {
+    @Test("Direct executor and host app use the legacy service-only keychain")
+    func directExecutorUsesHostAppServiceOnlyKeychain() throws {
         let projectRoot = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
             .deletingLastPathComponent()
@@ -452,10 +452,12 @@ struct ScriptExecutorTests {
             contentsOf: projectRoot.appendingPathComponent("SaneClick/SaneClickApp.swift"),
             encoding: .utf8
         )
-        let accessGroup = "M78L6FXD48.group.com.saneclick.app"
+        let serviceOnlyKeychain = #"keychain: KeychainService(service: "com.saneclick.SaneClick")"#
 
-        #expect(executorSource.contains("accessGroup: \"\(accessGroup)\""))
-        #expect(appSource.contains("accessGroup: \"\(accessGroup)\""))
+        #expect(executorSource.components(separatedBy: serviceOnlyKeychain).count - 1 == 2)
+        #expect(appSource.components(separatedBy: serviceOnlyKeychain).count - 1 == 2)
+        #expect(!executorSource.contains("accessGroup:"))
+        #expect(!appSource.contains("accessGroup:"))
     }
 
     @Test("Built-in actions never pre-set a non-standard output mode")


### PR DESCRIPTION
Removes the unsupported macOS-style app-group identifier from SaneClick's direct Keychain configuration while preserving the Finder app-group entitlement. Adds a guardrail against reintroducing the invalid access group.\n\nMini verification: 189 tests in 22 suites passed (receipt 02afb4e9586d20fc4d98ebffad630417).