### PR TITLE
Expose visible custom-action controls for SaneClick 1.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to SaneClick are documented here.
 
 ---
 
+## [1.3.3] - 2026-07-29
+
+Restores direct-download license recognition for SaneApps bundle purchases.
+
 ## [1.3.2] - 2026-07-27
 
 Improves fresh-install Finder setup and custom action editing. Also polishes

--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -4,7 +4,7 @@
 **Current public version:** `1.3.1` (build `1301`)
 **Release candidate:** `1.3.3` (build `1303`)
 **Release branch:** `codex/saneclick-1.3.3`
-**Audited commit:** `a475245364eb216e8905f68a8d91218769431cef`
+**Audited commit:** `37c64a697b8cef6b8971afa6b6412ecf2be3bc5a`
 
 ## Active Release State
 
@@ -22,7 +22,8 @@ Public release note:
 - Installed-runner acceptance returned status 0 with Finder frontmost, Terminal hidden, and zero accessibility-visible automation windows.
 - The 1.3.3 custom-action manager now exposes visible, bright-white Edit and Remove controls. This fixes the Mini proof blocker where the row context menu did not appear through right-click, control-click, or its accessibility action.
 - The focused visible-control guardrail and full canonical Mini verify passed: 190 tests in 22 suites. Workflow receipt: `3dab6efba777a4c98dbf4a7a460cb978`.
-- Customer UI contract passed with all eight release actions covered: `03b0e58354c8e9e4c9060ae30732d8fe`.
+- The earlier customer UI contract-only sweep passed source/manifest coverage:
+  `03b0e58354c8e9e4c9060ae30732d8fe`. It is not an eight-action runtime receipt.
 - Signed Release launch log: `outputs/runtime/saneclick-1.3.2-live.log`.
 - Fresh direct-install Settings proof: `outputs/customer-ui/settings-fresh-direct-monitored-folders.png`.
 - Signed-release Finder action produced a timestamped duplicate: `outputs/e2e/1.3.2/SaneClick-E2E-132_20260728_140633.txt`.
@@ -31,6 +32,74 @@ Public release note:
 The customer UI sweep receipt above established source and contract coverage. It did not execute every manifest click or Finder action. `scripts/customer_ui_action_sweep.rb` now writes contract-only receipts unless a separate Mini runner supplies action-level execution evidence.
 
 Expected pre-publish warnings: public appcast and Homebrew remain on 1.3.1 until release, unrelated pending support email exists, and the audit ran in the evening.
+
+## Fixed 1.3.3 Customer Proof — 2026-07-30
+
+Candidate `37c64a697b8cef6b8971afa6b6412ecf2be3bc5a` passed the canonical Mini verify twice: 190 tests in 22 suites, receipt `3dab6efba777a4c98dbf4a7a460cb978` and pre-push receipt prefix `269e115`. The signed Release candidate launch receipt prefixes are `e7a027` and `5d9b4d`. No release or upload ran.
+
+The fresh fixed-binary proof root is `outputs/customer-ui/1.3.3-20260730T054618Z-fixed/`.
+
+1. **Passed — main category Enable All.** Transcript:
+   `actions/01-main-category-enable-all.log`; screenshot:
+   `screenshots/01-main-category-enable-all.png`.
+2. **Passed — individual main-action toggle.** Transcript:
+   `actions/02-main-individual-action-toggle.log`; screenshot:
+   `screenshots/02-main-individual-action-toggle.png`.
+3. **Passed — Script Library global controls.** The live read-back was
+   `62/62 -> 1/62 -> 62/62`, with the global checkbox reading
+   `1 -> 0 -> 1`. Transcript:
+   `actions/03-script-library-global-enable-all.log`; screenshot:
+   `screenshots/03-script-library-global-enable-all.png`. The earlier invalid
+   diagnostic is retained as
+   `actions/03-script-library-global-enable-all-invalid-readback.log` and
+   `actions/03-readback-blocker.png`.
+4. **Passed — Script Library category controls.** All five categories expanded;
+   a category and its first row toggled off/on; final state returned to
+   `62 of 62 enabled`. Transcript:
+   `actions/04-script-library-category-controls.log`; screenshot:
+   `screenshots/04-script-library-category-controls.png`.
+5. **Passed — custom-action management.** Created `MD5 Hash`, saved body
+   `echo CUSTOM_PROOF_FIXED_V2`, relaunched, edited it through the visible Edit
+   button to `V3`, toggled it `1 -> 0 -> 1`, then used the visible Remove button
+   and real confirmation dialog. The post-delete manager contained only
+   `Start Python Server`, and the backing store was `[]`. Transcript:
+   `actions/05-custom-action-management.log`; canonical screenshot:
+   `screenshots/05-custom-action-management.png`; state receipts:
+   `fixtures/05-custom-action-state-before-delete.json` and
+   `fixtures/05-custom-action-state-after-delete.json`.
+6. **Passed — Settings tabs and status.** General refreshed to
+   `Extension Active`; General, Visibility, Updates, License, and About were
+   selected and read through accessibility; Report a Bug opened only to its
+   safe first surface and sent nothing; Privacy reached the end and displayed
+   the local-data/public-GitHub warning. Canonical screenshot:
+   `screenshots/06-settings-tabs-and-status.png`; transcript:
+   `actions/06-settings-tabs-and-status.log`. The live License state was
+   `Licensed`, so trial/$14.99 copy was not visible in this run.
+7. **Blocked — real Finder menu action execution.** Direct-SSH `cliclick`, the
+   researched Terminal/TCC context, and the System Events path did not expose a
+   readable Finder context menu. The diagnostic desktop capture also stalled.
+   The disposable fixture inventory remained unchanged and no Finder action
+   produced a side effect. Retained evidence:
+   `fixtures/07-before-inventory.txt`. There is no Action 7 pass screenshot.
+8. **Not run / blocked by Action 7.** The fresh direct-install monitored-folder
+   flow did not run because the required one-app proof sequence stopped at the
+   Action 7 blocker. There is no Action 8 receipt.
+
+This run is **not 8/8**. Do not run release/App Store preflights or claim
+release readiness from it.
+
+Cleanup completed after the blocker:
+
+- The disposable Mini fixture directory
+  `/Users/stephansmac/Downloads/SaneClick-Proof-20260730T054618Z` was moved to
+  the Mini Trash and is recoverable there.
+- Exact owned Mini processes were stopped: SaneClick PID `21641`, Finder
+  extension PID `21642`, and live logger PID `17829`.
+- The controller-side logger pipeline PGID `42693` (`ssh` PID `42704`, `tee`
+  PID `42705`) exited.
+- Final process read-back found zero SaneClick, logger, `mini-gui-run`,
+  `cliclick`, or screenshot-helper processes. The proof Finder window was gone;
+  Finder showed `Downloads`.
 
 ## Current Visual Proof
 
@@ -49,9 +118,12 @@ The Finder demo and pitch videos were frame-inspected on the Mini on 2026-07-28.
 
 ## Remaining Release Work
 
-1. Rerun all eight customer UI actions on the exact fixed 1.3.3 binary. Earlier 2026-07-30 actions 1–4 are diagnostic only because the visible custom-action control changes the candidate fingerprint.
-2. Run the guarded release and App Store preflights on the clean 1.3.3 commit.
-3. Publish 1.3.3, then verify the appcast, Homebrew cask, website, checkout, and hosted download.
+1. Fix or formally replace the blocked Finder action proof path, then rerun
+   Actions 7 and 8 on the exact fixed 1.3.3 candidate.
+2. Only after an honest eight-action runtime result, run the guarded release
+   and App Store preflights.
+3. Publish 1.3.3 only with owner approval, then verify the appcast, Homebrew
+   cask, website, checkout, and hosted download.
 
 ## End-of-day preservation
 

--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -1,9 +1,10 @@
 # Session Handoff — SaneClick
 
-**Last updated:** 2026-07-28
+**Last updated:** 2026-07-29
 **Current public version:** `1.3.1` (build `1301`)
-**Release candidate:** `1.3.2` (build `1302`)
-**Audited commit:** `b5fc2a952c202348e10f5816c8eac5c16f0b8711`
+**Release candidate:** `1.3.3` (build `1303`)
+**Release branch:** `codex/saneclick-1.3.3`
+**Audited commit:** `a475245364eb216e8905f68a8d91218769431cef`
 
 ## Active Release State
 
@@ -15,6 +16,10 @@ Public release note:
 
 ### Current Mini receipts
 
+- The signed 1.3.3 owner build reached `License / Status / Licensed` through the real Settings UI on the Mini.
+- The Keychain access-group repair and its guardrail coverage are on the release branch. GitHub fixes #7 and #8 are merged.
+- The shared Mini GUI runner cleanup is merged in SaneProcess PRs #22 and #24. Focused tests passed 31/31.
+- Installed-runner acceptance returned status 0 with Finder frontmost, Terminal hidden, and zero accessibility-visible automation windows.
 - 188 tests in 22 suites passed. Log: `outputs/verify/20260728T173755.694477Z-7777-691dfeca/01-test.log`.
 - Customer UI contract passed with all eight release actions covered: `03b0e58354c8e9e4c9060ae30732d8fe`.
 - Signed Release launch log: `outputs/runtime/saneclick-1.3.2-live.log`.
@@ -43,9 +48,17 @@ The Finder demo and pitch videos were frame-inspected on the Mini on 2026-07-28.
 
 ## Remaining Release Work
 
-1. Commit and push the verified 1.3.2 candidate.
-2. Run the guarded release and App Store preflights on the clean commit.
-3. Publish 1.3.2, then verify the appcast, Homebrew cask, website, checkout, and hosted download.
+1. Repair the Mini screenshot wrapper. Two bounded attempts on 2026-07-29 returned no new image, so there is no fresh visual receipt for the 1.3.3 licensed state.
+2. Run the guarded release and App Store preflights on the clean 1.3.3 commit.
+3. Publish 1.3.3, then verify the appcast, Homebrew cask, website, checkout, and hosted download.
+
+## End-of-day preservation
+
+- Air release checkout is clean at `a475245364eb216e8905f68a8d91218769431cef`.
+- Mini primary checkout is clean on `main` at `2bbd52cf3367c108256616050bf2eca6ebd60f0c`.
+- The old Mini Keychain worktree changes are recoverable in stash `18ea4473c396060014ea9d3127f368c637bac956`.
+- The stale Mini release-worktree state is recoverable in stash `2bcf448e1715d7f51fc46de6ba2c686d93709db0`.
+- Both stale linked worktrees were removed after checkpointing; the primary checkout is the only remaining SaneClick worktree on the Mini.
 
 ## Archive
 

--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -1,6 +1,6 @@
 # Session Handoff — SaneClick
 
-**Last updated:** 2026-07-29
+**Last updated:** 2026-07-30
 **Current public version:** `1.3.1` (build `1301`)
 **Release candidate:** `1.3.3` (build `1303`)
 **Release branch:** `codex/saneclick-1.3.3`
@@ -20,7 +20,8 @@ Public release note:
 - The Keychain access-group repair and its guardrail coverage are on the release branch. GitHub fixes #7 and #8 are merged.
 - The shared Mini GUI runner cleanup is merged in SaneProcess PRs #22 and #24. Focused tests passed 31/31.
 - Installed-runner acceptance returned status 0 with Finder frontmost, Terminal hidden, and zero accessibility-visible automation windows.
-- 188 tests in 22 suites passed. Log: `outputs/verify/20260728T173755.694477Z-7777-691dfeca/01-test.log`.
+- The 1.3.3 custom-action manager now exposes visible, bright-white Edit and Remove controls. This fixes the Mini proof blocker where the row context menu did not appear through right-click, control-click, or its accessibility action.
+- The focused visible-control guardrail and full canonical Mini verify passed: 190 tests in 22 suites. Workflow receipt: `3dab6efba777a4c98dbf4a7a460cb978`.
 - Customer UI contract passed with all eight release actions covered: `03b0e58354c8e9e4c9060ae30732d8fe`.
 - Signed Release launch log: `outputs/runtime/saneclick-1.3.2-live.log`.
 - Fresh direct-install Settings proof: `outputs/customer-ui/settings-fresh-direct-monitored-folders.png`.
@@ -48,7 +49,7 @@ The Finder demo and pitch videos were frame-inspected on the Mini on 2026-07-28.
 
 ## Remaining Release Work
 
-1. Repair the Mini screenshot wrapper. Two bounded attempts on 2026-07-29 returned no new image, so there is no fresh visual receipt for the 1.3.3 licensed state.
+1. Rerun all eight customer UI actions on the exact fixed 1.3.3 binary. Earlier 2026-07-30 actions 1–4 are diagnostic only because the visible custom-action control changes the candidate fingerprint.
 2. Run the guarded release and App Store preflights on the clean 1.3.3 commit.
 3. Publish 1.3.3, then verify the appcast, Homebrew cask, website, checkout, and hosted download.
 

--- a/SaneClick.xcodeproj/project.pbxproj
+++ b/SaneClick.xcodeproj/project.pbxproj
@@ -706,7 +706,7 @@
 				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = YES;
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1302;
+				CURRENT_PROJECT_VERSION = 1303;
 				DEVELOPMENT_TEAM = M78L6FXD48;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = SaneClick/Info.plist;
@@ -715,7 +715,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.3.2;
+				MARKETING_VERSION = 1.3.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.saneclick.SaneClick;
 				PRODUCT_NAME = SaneClick;
 				SDKROOT = macosx;
@@ -823,7 +823,7 @@
 				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = YES;
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1302;
+				CURRENT_PROJECT_VERSION = 1303;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = "SaneClick/Info-AppStore.plist";
 				INFOPLIST_KEY_AppStoreProductID = com.saneclick.app.pro.actions.v4;
@@ -832,7 +832,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.3.2;
+				MARKETING_VERSION = 1.3.3;
 				OTHER_SWIFT_FLAGS = "$(inherited) -D APP_STORE";
 				PRODUCT_BUNDLE_IDENTIFIER = com.saneclick.SaneClick;
 				PRODUCT_NAME = SaneClick;
@@ -900,7 +900,7 @@
 				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = YES;
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1302;
+				CURRENT_PROJECT_VERSION = 1303;
 				DEVELOPMENT_TEAM = M78L6FXD48;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = "SaneClick/Info-AppStore.plist";
@@ -910,7 +910,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.3.2;
+				MARKETING_VERSION = 1.3.3;
 				OTHER_SWIFT_FLAGS = "$(inherited) -D APP_STORE";
 				PRODUCT_BUNDLE_IDENTIFIER = com.saneclick.SaneClick;
 				PRODUCT_NAME = SaneClick;
@@ -1016,12 +1016,12 @@
 				CODE_SIGN_IDENTITY = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1302;
+				CURRENT_PROJECT_VERSION = 1303;
 				DEVELOPMENT_TEAM = M78L6FXD48;
 				INFOPLIST_FILE = SaneClickExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @executable_path/../../../../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.3.2;
+				MARKETING_VERSION = 1.3.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.saneclick.SaneClick.FinderSync;
 				PRODUCT_NAME = SaneClickExtension;
 				SDKROOT = macosx;
@@ -1043,7 +1043,7 @@
 				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = YES;
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1302;
+				CURRENT_PROJECT_VERSION = 1303;
 				DEVELOPMENT_TEAM = M78L6FXD48;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = "SaneClick/Info-AppStore.plist";
@@ -1053,7 +1053,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.3.2;
+				MARKETING_VERSION = 1.3.3;
 				OTHER_SWIFT_FLAGS = "$(inherited) -D APP_STORE";
 				PRODUCT_BUNDLE_IDENTIFIER = com.saneclick.SaneClick;
 				PRODUCT_NAME = SaneClick;
@@ -1094,12 +1094,12 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1302;
+				CURRENT_PROJECT_VERSION = 1303;
 				DEVELOPMENT_TEAM = M78L6FXD48;
 				INFOPLIST_FILE = SaneClickExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @executable_path/../../../../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.3.2;
+				MARKETING_VERSION = 1.3.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.saneclick.SaneClick.FinderSync;
 				PRODUCT_NAME = SaneClickExtension;
 				SDKROOT = macosx;
@@ -1146,7 +1146,7 @@
 				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = YES;
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1302;
+				CURRENT_PROJECT_VERSION = 1303;
 				DEVELOPMENT_TEAM = M78L6FXD48;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = SaneClick/Info.plist;
@@ -1155,7 +1155,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.3.2;
+				MARKETING_VERSION = 1.3.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.saneclick.SaneClick;
 				PRODUCT_NAME = SaneClick;
 				PROVISIONING_PROFILE_SPECIFIER = "SaneClick Mac App Store";
@@ -1201,7 +1201,7 @@
 				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = YES;
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1302;
+				CURRENT_PROJECT_VERSION = 1303;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = SaneClick/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1209,7 +1209,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.3.2;
+				MARKETING_VERSION = 1.3.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.saneclick.SaneClick;
 				PRODUCT_NAME = SaneClick;
 				SDKROOT = macosx;
@@ -1227,12 +1227,12 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1302;
+				CURRENT_PROJECT_VERSION = 1303;
 				DEVELOPMENT_TEAM = M78L6FXD48;
 				INFOPLIST_FILE = SaneClickExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @executable_path/../../../../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.3.2;
+				MARKETING_VERSION = 1.3.3;
 				OTHER_SWIFT_FLAGS = "$(inherited) -D APP_STORE";
 				PRODUCT_BUNDLE_IDENTIFIER = com.saneclick.SaneClick.FinderSync;
 				PRODUCT_NAME = SaneClickExtension;
@@ -1253,11 +1253,11 @@
 				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1302;
+				CURRENT_PROJECT_VERSION = 1303;
 				INFOPLIST_FILE = SaneClickExtension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @executable_path/../../../../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.3.2;
+				MARKETING_VERSION = 1.3.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.saneclick.SaneClick.FinderSync;
 				PRODUCT_NAME = SaneClickExtension;
 				SDKROOT = macosx;
@@ -1279,7 +1279,7 @@
 				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = YES;
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1302;
+				CURRENT_PROJECT_VERSION = 1303;
 				DEVELOPMENT_TEAM = M78L6FXD48;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = "SaneClick/Info-AppStore.plist";
@@ -1289,7 +1289,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.3.2;
+				MARKETING_VERSION = 1.3.3;
 				OTHER_SWIFT_FLAGS = "$(inherited) -D APP_STORE";
 				PRODUCT_BUNDLE_IDENTIFIER = com.saneclick.SaneClick;
 				PRODUCT_NAME = SaneClick;
@@ -1369,7 +1369,7 @@
 				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = YES;
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1302;
+				CURRENT_PROJECT_VERSION = 1303;
 				DEVELOPMENT_TEAM = M78L6FXD48;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = SaneClick/Info.plist;
@@ -1378,7 +1378,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.3.2;
+				MARKETING_VERSION = 1.3.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.saneclick.SaneClick;
 				PRODUCT_NAME = SaneClick;
 				SDKROOT = macosx;

--- a/SaneClick/Views/SettingsView.swift
+++ b/SaneClick/Views/SettingsView.swift
@@ -646,6 +646,30 @@ struct ScriptRow: View {
             .toggleStyle(.switch)
             .labelsHidden()
             .tint(successGreen)
+
+            Button(action: onEdit) {
+                Label("Edit", systemImage: "pencil")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(.white)
+            }
+            .buttonStyle(.plain)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 6)
+            .background(Color.saneSmoke)
+            .clipShape(RoundedRectangle(cornerRadius: 7))
+            .accessibilityIdentifier("editCustomActionButton")
+
+            Button(role: .destructive, action: onDelete) {
+                Label("Remove", systemImage: "trash")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(.white)
+            }
+            .buttonStyle(.plain)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 6)
+            .background(Color.saneSmoke)
+            .clipShape(RoundedRectangle(cornerRadius: 7))
+            .accessibilityIdentifier("removeCustomActionButton")
         }
         .padding(14)
         .background {

--- a/Tests/AppStoreReviewGuardrailTests.swift
+++ b/Tests/AppStoreReviewGuardrailTests.swift
@@ -122,6 +122,23 @@ struct AppStoreReviewGuardrailTests {
         #expect(appSource.contains("keyboardShortcut(\",\", modifiers: .command)") == false)
     }
 
+    @Test("Custom actions expose visible Edit and Remove controls")
+    func customActionsExposeVisibleEditAndRemoveControls() throws {
+        let projectRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let source = try String(
+            contentsOf: projectRoot.appendingPathComponent("SaneClick/Views/SettingsView.swift"),
+            encoding: .utf8
+        )
+        let scriptRow = try #require(source.components(separatedBy: "struct ScriptRow: View").last)
+
+        #expect(scriptRow.contains("Button(action: onEdit)"))
+        #expect(scriptRow.contains("accessibilityIdentifier(\"editCustomActionButton\")"))
+        #expect(scriptRow.contains("Button(role: .destructive, action: onDelete)"))
+        #expect(scriptRow.contains("accessibilityIdentifier(\"removeCustomActionButton\")"))
+    }
+
     @Test("Customer UI sweep keeps nested contract output machine readable")
     func customerUISweepSuppressesNestedWorkflowReceiptNoise() throws {
         let projectRoot = URL(fileURLWithPath: #filePath)

--- a/project.yml
+++ b/project.yml
@@ -120,8 +120,8 @@ targets:
         PRODUCT_NAME: SaneClick
         PRODUCT_BUNDLE_IDENTIFIER: com.saneclick.SaneClick
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
-        MARKETING_VERSION: "1.3.2"
-        CURRENT_PROJECT_VERSION: "1302"
+        MARKETING_VERSION: "1.3.3"
+        CURRENT_PROJECT_VERSION: "1303"
         ENABLE_PREVIEWS: YES
         SWIFT_VERSION: "6.0"
         SWIFT_STRICT_CONCURRENCY: complete
@@ -182,8 +182,8 @@ targets:
         INFOPLIST_KEY_AppStoreProductID: com.saneclick.app.pro.actions.v4
         PRODUCT_NAME: SaneClick
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
-        MARKETING_VERSION: "1.3.2"
-        CURRENT_PROJECT_VERSION: "1302"
+        MARKETING_VERSION: "1.3.3"
+        CURRENT_PROJECT_VERSION: "1303"
         ENABLE_PREVIEWS: YES
         SWIFT_VERSION: "6.0"
         SWIFT_STRICT_CONCURRENCY: complete
@@ -247,8 +247,8 @@ targets:
         INFOPLIST_FILE: SaneClickExtension/Info.plist
         PRODUCT_BUNDLE_IDENTIFIER: com.saneclick.SaneClick.FinderSync
         PRODUCT_NAME: SaneClickExtension
-        MARKETING_VERSION: "1.3.2"
-        CURRENT_PROJECT_VERSION: "1302"
+        MARKETING_VERSION: "1.3.3"
+        CURRENT_PROJECT_VERSION: "1303"
         SWIFT_VERSION: "6.0"
         SWIFT_STRICT_CONCURRENCY: complete
         MACOSX_DEPLOYMENT_TARGET: "14.0"


### PR DESCRIPTION
## Summary
- Add visible, bright-white Edit and Remove buttons to custom-action rows while keeping the existing handlers and confirmation flow.
- Prepare the 1.3.3 candidate metadata and record the fixed-binary customer proof.
- Record the honest proof boundary: Actions 1-6 passed; Actions 7-8 remain blocked; no release or upload ran.

## Test plan
- [x] Canonical Mini verify: 190 tests in 22 suites (`131515dc21585caa43f2d36f9f7b593b`).
- [x] Fixed-candidate customer proof Actions 1-6 passed with saved transcripts and screenshots.
- [ ] Action 7 real Finder menu execution is blocked after the researched direct SSH, Terminal/TCC, and System Events paths did not expose a readable context menu; diagnostic desktop capture also stalled.
- [ ] Action 8 was not run because the required proof sequence stopped at Action 7.
- [ ] Release and App Store preflights were intentionally not run. This PR does not claim 8/8 proof or release readiness.
